### PR TITLE
Add generated MAC and new omit vmx encoding option

### DIFF
--- a/api.go
+++ b/api.go
@@ -7,16 +7,24 @@ type Vhardware struct {
 
 type Ethernet struct {
 	VMXID                string
-	Address              string `vmx:"address,omitempty"`
-	StartConnected       bool   `vmx:"startconnected,omitempty"`
-	Present              bool   `vmx:"present"`
-	ConnectionType       string `vmx:"connectiontype,omitempty"`
-	VirtualDev           string `vmx:"virtualdev,omitempty"`
-	WakeOnPcktRcv        bool   `vmx:"wakeonpcktrcv,omitempty"`
-	AddressType          string `vmx:"addresstype,omitempty"`
-	LinkStatePropagation bool   `vmx:"linkstatepropagation.enable,omitempty"`
-	VNetwork             string `vmx:"vnet,omitempty"`
+	Address              string              `vmx:"address,omitempty"`
+	GeneratedAddress     string              `vmx:"generatedaddress,omit"`
+	StartConnected       bool                `vmx:"startconnected,omitempty"`
+	Present              bool                `vmx:"present"`
+	ConnectionType       string              `vmx:"connectiontype,omitempty"`
+	VirtualDev           string              `vmx:"virtualdev,omitempty"`
+	WakeOnPcktRcv        bool                `vmx:"wakeonpcktrcv,omitempty"`
+	AddressType          EthernetAddressType `vmx:"addresstype,omitempty"`
+	LinkStatePropagation bool                `vmx:"linkstatepropagation.enable,omitempty"`
+	VNetwork             string              `vmx:"vnet,omitempty"`
 }
+
+type EthernetAddressType string
+
+const (
+	MAC_TYPE_STATIC    = "static"
+	MAC_TYPE_GENERATED = "generated"
+)
 
 type Device struct {
 	VMXID          string
@@ -47,7 +55,7 @@ type USBDevice struct {
 	Speed   uint   `vmx:"speed,omitempty"`
 	Type    string `vmx:"devicetype,omitempty"`
 	Port    uint   `vmx:"port,omitempty"`
-	Parent  string `vmx:"parent,omitmepty"`
+	Parent  string `vmx:"parent,omitempty"`
 }
 
 type PowerType struct {

--- a/decode.go
+++ b/decode.go
@@ -137,7 +137,7 @@ func (d *Decoder) decode(val reflect.Value, key string) error {
 			continue
 		}
 
-		destKey, _, err := parseTag(tag)
+		destKey, _, _, err := parseTag(tag)
 		if err != nil {
 			continue
 		}

--- a/encode.go
+++ b/encode.go
@@ -54,13 +54,14 @@ func (e *Encoder) encode(val reflect.Value) error {
 
 		tag := typeField.Tag
 
-		key, omitempty, err := parseTag(string(tag))
+		key, omitempty, omit, err := parseTag(string(tag))
 		if err != nil {
 			return err
 		}
 
 		if key == "-" || !valueField.IsValid() ||
 			omitempty && isEmptyValue(valueField) ||
+			omit ||
 			key == "" && !typeField.Anonymous {
 			continue
 		}

--- a/encode_test.go
+++ b/encode_test.go
@@ -10,21 +10,28 @@ func TestParsingTag(t *testing.T) {
 		tag       string
 		name      string
 		omitempty bool
+		omit      bool
 		err       string
 	}{
-		{"vmx:displayname", "", false, "Tag name has to be enclosed in double quotes: vmx:displayname"},
-		{"vmx:", "", false, "Invalid tag: vmx:"},
-		{`vmx:""`, "", false, `Tag name is missing: vmx:""`},
-		{"vm", "", false, "Invalid tag: vm"},
-		{`vmx:"displayname,omitempty`, "displayname", true, ""},
-		{`vmx:"displayname,blah"`, "displayname", false, ""},
-		{`vmx:"-"`, "-", false, ""},
+		{"vmx:displayname", "", false, false, "Tag name has to be enclosed in double quotes: vmx:displayname"},
+		{"vmx:", "", false, false, "Invalid tag: vmx:"},
+		{`vmx:""`, "", false, false, `Tag name is missing: vmx:""`},
+		{"vm", "", false, false, "Invalid tag: vm"},
+		{`vmx:"displayname1,omitempty`, "displayname1", true, false, ""},
+		{`vmx:"displayname2"`, "displayname2", false, false, ""},
+		{`vmx:"-"`, "-", false, false, ""},
+		{`vmx:"displayname3,omit`, "displayname3", false, true, ""},
+		{`vmx:"displayname4,omitempty,omit`, "displayname4", true, true, ""},
+		{`vmx:"displayname5,omit,omitempty`, "displayname5", true, true, ""},
+		{`vmx:"displayname6,omit , omitempty`, "displayname6", true, true, ""},
+		{`vmx:"displayname7 , omit , omitempty `, "displayname7", true, true, ""},
 	}
 
 	for _, tt := range tests {
-		name, omitempty, err := parseTag(tt.tag)
+		name, omitempty, omit, err := parseTag(tt.tag)
 		equals(t, tt.name, name)
 		equals(t, tt.omitempty, omitempty)
+		equals(t, tt.omit, omit)
 		if err != nil {
 			equals(t, tt.err, err.Error())
 		} else {
@@ -125,15 +132,17 @@ func TestMarshalArray(t *testing.T) {
 			VirtualDev:           "e1000",
 			WakeOnPcktRcv:        false,
 			AddressType:          "generated",
+			GeneratedAddress:     "00:0c:29:20:41:a3",
 			LinkStatePropagation: true,
 		},
 		{
-			StartConnected: true,
-			Present:        true,
-			ConnectionType: "nat",
-			VirtualDev:     "e1000",
-			WakeOnPcktRcv:  false,
-			AddressType:    "generated",
+			StartConnected:   true,
+			Present:          true,
+			ConnectionType:   "nat",
+			VirtualDev:       "e1000",
+			WakeOnPcktRcv:    false,
+			AddressType:      "generated",
+			GeneratedAddress: "00:0c:29:20:41:a3",
 		},
 	}
 


### PR DESCRIPTION
I needed the generated MAC, so added it to Ethernet in the vmx model with a new omit encoding option to ensure the generated MAC is never marshaled back out.
